### PR TITLE
Bug fix: OptionProvider issue for Select in combination with ManyToManyObjectRelation

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -830,6 +830,10 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
             return $this;
         }
 
+        if (!isset($context['purpose'])) {
+            $context['purpose'] = 'layout';
+        }
+
         $this->visibleFieldDefinitions = [];
 
         $translator = \Pimcore::getContainer()->get('translator');

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -591,6 +591,10 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
         if (!$class) {
             return $this;
         }
+        
+        if (!isset($context['purpose'])) {
+            $context['purpose'] = 'layout';
+        }
 
         $this->visibleFieldDefinitions = [];
 


### PR DESCRIPTION
There is an issue with OptionProvider for Select and Multiselect in combination with ManyToManyObjectRelation and AdvancedManyToManyObjectRelation. The error is only visible if the OptionProvider delivers specific values based on purpose 'layout' (to identify UI layout usage, see documentation [Object_Classes/Data_Types/Dynamic_Select_Types](https://pimcore.com/docs/pimcore/current/Development_Documentation/Objects/Object_Classes/Data_Types/Dynamic_Select_Types.html). If the same OptionProvider is also used for the object class of the reference it shows wrong content/format of list elements.

## Additional info
To test you need
- OptionProvider returning different key strings for the values on purpose 'layout'
- Object class with Select or Multiselect field using this OptionProvider
- ManyToManyObjectRelation or AdvancedManyToManyObjectRelation field in same Object class referencing to object of its own class
- Create object of new class will show wrong values in select field
- Using the same OptionProvider in a class with Select or Multiselect field but without Relation fields will work

### WHAT

In case an object class has field(s) of Select and/or Multiselect data type using OptiosProvider and also field(s) of ManyToManyObjectRelation and/or AdvancedManyToManyObjectRelation data type referring to object using the same OptionProvider, this OptionProvider will fail to deliver correct data based on purpose 'layout'. The reason for the problem is, that for the objects which may be listed in relation fields again the field definitions are determined. But here we miss the context parameter purpose and then enrichFieldDefinition is used instead of enrichLayoutDefinition and therefore the OptionProvider is called with purpose 'fielddefinition' instead of 'layout'.

#### Call flow examples
Here the call flow for a Select field on opening an object in UI where the OptionProvider works as expected:
```
- Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController->getAction
-- Pimcore\Model\DataObject\Service::enrichLayoutDefinition
--- Pimcore\Model\DataObject\ClassDefinition\Data\Select->enrichLayoutDefinition
---- Pimcore\Model\DataObject\ClassDefinition\Data\Select->doEnrichDefinitionDefinition   (called with parameter $purpose = 'layout', setting context['purpose'])
----- App\OptionsProvider\MyOptionsProvider->getOptions   (called with  context['purpose'] = 'layout' -> correct)
```
The same call flow for a AdvancedManyToManyObjectRelation field containing object of the same class:
```
- Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController->getAction
-- Pimcore\Model\DataObject\Service::enrichLayoutDefinition
--- Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation->enrichLayoutDefinition   (Here we still know we are in layout mode!)
---- Pimcore\Model\DataObject\ClassDefinition->getFieldDefinitions
----- Pimcore\Model\DataObject\ClassDefinition->doEnrichFieldDefinition
------ Pimcore\Model\DataObject\ClassDefinition\Data\Select->enrichFieldDefinition 
------- Pimcore\Model\DataObject\ClassDefinition\Data\Select->doEnrichDefinitionDefinition   (called with parameter $purpose = 'fielddefinition', setting context['purpose'])
-------- App\OptionsProvider\MyOptionsProvider->getOptions   (called with  context['purpose'] = 'fielddefinition' -> error)
```
### HOW
The easiest way to correct this is to set the context in *ManyToManyObjectRelation->enrichLayoutDefinition as this is the last point we still know we are in layout mode and this context is then passed on anyhow.

#### Call flow example
The call flow for the AdvancedManyToManyObjectRelation field will not change but we have the correct setting to work properly:
```
- Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController->getAction
-- Pimcore\Model\DataObject\Service::enrichLayoutDefinition
--- Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation->enrichLayoutDefinition   (Here we are setting context['purpose'] to 'layout')
---- Pimcore\Model\DataObject\ClassDefinition->getFieldDefinitions
----- Pimcore\Model\DataObject\ClassDefinition->doEnrichFieldDefinition
------ Pimcore\Model\DataObject\ClassDefinition\Data\Select->enrichFieldDefinition 
------- Pimcore\Model\DataObject\ClassDefinition\Data\Select->doEnrichDefinitionDefinition   (called with parameter $purpose = 'fielddefinition', but no change of context['purpose'] as it is already defined)
-------- App\OptionsProvider\MyOptionsProvider->getOptions   (called with  context['purpose'] = 'layout' -> correct)
```
