### PR TITLE
Bug fix: layout issue for not_editable structuredTable

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/structuredTable.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/structuredTable.js
@@ -218,7 +218,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
         }
 
         var columns = [
-            {text: "", width: 80, sortable: false, dataIndex: '__row_label', editor: null,
+            {text: t(this.fieldConfig.labelFirstCell), width: this.fieldConfig.labelWidth, sortable: false, dataIndex: '__row_label', editor: null,
                 renderer: function(value, metaData) {
                                 metaData.tdCls = 'x-grid3-hd-row';
                                 return t(value);
@@ -228,7 +228,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
 
         for(var i = 0; i < this.fieldConfig.cols.length; i++) {
 
-            var columnConfig = {text: t(this.fieldConfig.cols[i].label), width: 120, sortable: false,
+            var columnConfig = {text: t(this.fieldConfig.cols[i].label), width: this.fieldConfig.cols[i].width, sortable: false,
                 dataIndex: this.fieldConfig.cols[i].key, editor: null};
             if(this.fieldConfig.cols[i].type == "bool") {
                 columnConfig.renderer = function (value, metaData, record, rowIndex, colIndex, store) {


### PR DESCRIPTION
Correction to use configured values of class definition in getLayoutShow for structuredTable instead of static default. The problem exists only for not_editable structuredTables, in edit mode the defined values are used

## Changes in this pull request
Resolves layout issue for not_editable structuredTable

## Additional info
### WHAT
not_editable structuredTable do not show the label string of the first column and do not use any of the column width values from class definition. The problem does not exist for editable elements

### HOW

1. create object class with structured table
2. define "Label Width" and "Label First Cell"
3. add Columns with value for "Width" other than 120 (which is static default)
4. select "not_editable" check box
5. create object for that class -> not width value used for rendering and defined label not visible