### PR TITLE
Fix maintenance task for object bricks and field collections on db with lower case table names

### DIFF
--- a/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
@@ -26,6 +26,8 @@ use Psr\Log\LoggerInterface;
  */
 class CleanupBrickTablesTask implements TaskInterface
 {
+    const PIMCORE_OBJECTBRICK_CLASS_DIRECTORY = PIMCORE_CLASS_DIRECTORY . '/DataObject/Objectbrick/Data';
+
     /**
      * @var LoggerInterface
      */
@@ -39,8 +41,7 @@ class CleanupBrickTablesTask implements TaskInterface
     {
         $this->logger = $logger;
         
-        $obPath = PIMCORE_CLASS_DIRECTORY . '/DataObject/Objectbrick/Data';
-        $files = array_diff(scandir($obPath), array('..', '.'));
+        $files = array_diff(scandir(self::PIMCORE_OBJECTBRICK_CLASS_DIRECTORY), array('..', '.'));
         foreach ($files as $file) {
             $classname = str_replace('.php','',$file);
             $class = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . $classname;

--- a/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
@@ -29,6 +29,7 @@ class CleanupFieldcollectionTablesTask implements TaskInterface
      * @var LoggerInterface
      */
     private $logger;
+    private $mapLowerToCamelCase = [];
 
     /**
      * @param LoggerInterface $logger
@@ -36,6 +37,15 @@ class CleanupFieldcollectionTablesTask implements TaskInterface
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
+        
+        $fcPath = PIMCORE_CLASS_DIRECTORY . '/DataObject/Fieldcollection/Data';
+        $files = array_diff(scandir($fcPath), array('..', '.'));
+        foreach ($files as $file) {
+            $classname = str_replace('.php','',$file);
+            $class = '\\Pimcore\\Model\\DataObject\\Fieldcollection\\Data\\' . $classname;
+            $object = new $class();
+            $this->mapLowerToCamelCase[strtolower($classname)] = $object->getType();
+        }
     }
 
     /**
@@ -63,6 +73,7 @@ class CleanupFieldcollectionTablesTask implements TaskInterface
                 $fieldDescriptor = substr($tableName, strlen($prefix));
                 $idx = strpos($fieldDescriptor, '_');
                 $fcType = substr($fieldDescriptor, 0, $idx);
+                $fcType = $this->mapLowerToCamelCase[$fcType] ?? $fcType;
 
                 $fcDef = \Pimcore\Model\DataObject\Fieldcollection\Definition::getByKey($fcType);
                 if (!$fcDef) {

--- a/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
@@ -25,6 +25,8 @@ use Psr\Log\LoggerInterface;
  */
 class CleanupFieldcollectionTablesTask implements TaskInterface
 {
+    const PIMCORE_FIELDCOLLECTION_CLASS_DIRECTORY = PIMCORE_CLASS_DIRECTORY . '/DataObject/Fieldcollection/Data';
+
     /**
      * @var LoggerInterface
      */
@@ -38,8 +40,7 @@ class CleanupFieldcollectionTablesTask implements TaskInterface
     {
         $this->logger = $logger;
         
-        $fcPath = PIMCORE_CLASS_DIRECTORY . '/DataObject/Fieldcollection/Data';
-        $files = array_diff(scandir($fcPath), array('..', '.'));
+        $files = array_diff(scandir(self::PIMCORE_FIELDCOLLECTION_CLASS_DIRECTORY), array('..', '.'));
         foreach ($files as $file) {
             $classname = str_replace('.php','',$file);
             $class = '\\Pimcore\\Model\\DataObject\\Fieldcollection\\Data\\' . $classname;


### PR DESCRIPTION
This PR referes to bug https://github.com/pimcore/pimcore/issues/10427 which is caused by getting type names of ObjectBricks and FieldCollections from database table names and using these names for checking if the ObjectBricks and FieldCollections exist. When databases are created with lower_case_table_names the name to be checked will be with lowercase letters only although the definition of ObjectBricks and FieldCollections might have uppercase characters too.

We need somehow a possibility to get from the lowercase stringto the one used to create the ObjectBricks and FieldCollections. The best way I could find is to create a mapping table to find the correct name with uppercase letters for names with only lowercase based on the class files which ensures that all relevant classes are considered, not only the ones currently loaded.

The error can be reproduced by
- using databse with `lower_case_table_names `set
- creating an ObjectBrick and a FieldCollection with uppercase letter in the name
- run maintenance job

As a result you will see error messages in the log file complaining missing types:
- `app.ERROR: Brick 'brickname' not found. Please check table object_brick_query_brickname_objectname`
- `app.ERROR: Fieldcollection 'collectionname' not found. Please check table object_collection_collectionname_objectname`

## Changes in this pull request

Resolves https://github.com/pimcore/pimcore/issues/10427