### PR TITLE
Introduce event to handle object edit lock

### DIFF
--- a/lib/Event/AdminEvents.php
+++ b/lib/Event/AdminEvents.php
@@ -372,6 +372,20 @@ final class AdminEvents
     const DOCUMENT_TREE_GET_CHILDREN_BY_ID_PRE_SEND_DATA = 'pimcore.admin.document.treeGetChildsById.preSendData';
 
     /**
+     * Fired before the edit lock is handled.
+     *
+     * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController
+     * Arguments:
+     *  - data | array | editLock behaviour, this can be modified
+     *  - object | AbstractObject | the current object
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const OBJECT_GET_IS_LOCKED = 'pimcore.admin.dataobject.get.isLocked';
+
+    /**
      * Fired before the request params are parsed.
      *
      * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController

--- a/models/Element/Editlock.php
+++ b/models/Element/Editlock.php
@@ -28,6 +28,18 @@ use Pimcore\Tool\Session;
 final class Editlock extends Model\AbstractModel
 {
     /**
+     * On active edit lock answer with editlock response
+     */
+    const TASK_RESPONSE = 'response';
+    /**
+     * On active edit lock overwrite with new user
+     */
+    const TASK_OVERWRITE = 'overwrite';
+    /**
+     * On active edit lock keep existing entry
+     */
+    const TASK_KEEP = 'keep';
+    /**
      * @var int
      */
     protected $id;


### PR DESCRIPTION
## Issue  
The current implementation has a fix behaviour in case of parallel access of objects by users in admin UI. The first user opens the object and it gets a lock entry. The second user is prompted to take over this lock.

I need a more flexible implementation to have the possibility to keep the lock and e.g. offer the object for the second one in read only.

## Changes in this pull request  
This PR introduces a new event which is triggered in case of user tries to open a locked object. Based on the event the implementation can decide to

- Offer the dialog as up to now to override the lock
- Keep the existing lock
- Override the lock without asking the user

Additional actions (like ensure read only access) can anyhow be taken and the pre edit event

## Additional info  

New admin event `pimcore.admin.dataobject.get.isLocked` is introduced which supports a parameter `task `with following possible values:

- `Editlock::TASK_RESPONSE`
- `Editlock::TASK_OVERWRITE`
- `Editlock::TASK_KEEP`

This task will be executed when event returns