### PR TITLE
Hide buttons of table if not editable

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
@@ -158,49 +158,54 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
 
         this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {});
 
-        var tbar = [];
+        var tbar = null;
 
-        if (!this.fieldConfig.colsFixed || columns.length < this.fieldConfig.cols) {
+        if (!this.fieldConfig.noteditable)
+        {
+            var tbar = [];
+
+            if (!this.fieldConfig.colsFixed || columns.length < this.fieldConfig.cols) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_col pimcore_icon_overlay_add",
+                    handler: this.addColumn.bind(this)
+                });
+            }
+
+            if (!this.fieldConfig.colsFixed || columns.length > this.fieldConfig.cols) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_col pimcore_icon_overlay_delete",
+                    handler: this.deleteColumn.bind(this)
+                });
+            }
+
+            if (!this.fieldConfig.rowsFixed || data.length != this.fieldConfig.rows) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_delete",
+                    handler: this.deleteRow.bind(this)
+                });
+
+                tbar.push({
+                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
+                    handler: this.addRow.bind(this)
+                });
+            }
+
             tbar.push({
-                iconCls: "pimcore_icon_table_col pimcore_icon_overlay_add",
-                handler: this.addColumn.bind(this)
+                iconCls: 'pimcore_icon_copy',
+                handler: this.copyFromTable.bind(this)
+            });
+
+            tbar.push({
+                iconCls: "pimcore_icon_paste",
+                handler: this.pasteFromClipboard.bind(this)
+            });
+
+
+            tbar.push({
+                iconCls: "pimcore_icon_empty",
+                handler: this.emptyStore.bind(this)
             });
         }
-
-        if (!this.fieldConfig.colsFixed || columns.length > this.fieldConfig.cols) {
-            tbar.push({
-                iconCls: "pimcore_icon_table_col pimcore_icon_overlay_delete",
-                handler: this.deleteColumn.bind(this)
-            });
-        }
-
-        if (!this.fieldConfig.rowsFixed || data.length != this.fieldConfig.rows) {
-            tbar.push({
-                iconCls: "pimcore_icon_table_row pimcore_icon_overlay_delete",
-                handler: this.deleteRow.bind(this)
-            });
-
-            tbar.push({
-                iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
-                handler: this.addRow.bind(this)
-            });
-        }
-
-        tbar.push({
-            iconCls: 'pimcore_icon_copy',
-            handler: this.copyFromTable.bind(this)
-        });
-
-        tbar.push({
-            iconCls: "pimcore_icon_paste",
-            handler: this.pasteFromClipboard.bind(this)
-        });
-
-
-        tbar.push({
-            iconCls: "pimcore_icon_empty",
-            handler: this.emptyStore.bind(this)
-        });
 
         this.grid = Ext.create('Ext.grid.Panel', {
             store: this.store,


### PR DESCRIPTION
If a table is readonly in Edit tab of an object in Admin UI it does not make sense to show inactive buttons for table modifications